### PR TITLE
[Issue 3] 게임오버 시 잘못꽂은 깃발 표시 

### DIFF
--- a/run.py
+++ b/run.py
@@ -38,7 +38,7 @@ class Renderer:
         y = config.margin_top + row * config.cell_size
         return Rect(x, y, config.cell_size, config.cell_size)
 
-    def draw_cell(self, col: int, row: int, highlighted: bool) -> None:
+    def draw_cell(self, col: int, row: int, highlighted: bool,game_over:bool) -> None:  #added game_over:bool
         """Draw a single cell, respecting revealed/flagged state and highlight."""
         cell = self.board.cells[self.board.index(col, row)]
         rect = self.cell_rect(col, row)
@@ -55,20 +55,24 @@ class Renderer:
             base_color = config.color_highlight if highlighted else config.color_cell_hidden
             pygame.draw.rect(self.screen, base_color, rect)
             if cell.state.is_flagged:
-                flag_w = max(6, rect.width // 3)
-                flag_h = max(8, rect.height // 2)
-                pole_x = rect.left + rect.width // 3
-                pole_y = rect.top + 4
-                pygame.draw.line(self.screen, config.color_flag, (pole_x, pole_y), (pole_x, pole_y + flag_h), 2)
-                pygame.draw.polygon(
-                    self.screen,
-                    config.color_flag,
-                    [
-                        (pole_x + 2, pole_y),
-                        (pole_x + 2 + flag_w, pole_y + flag_h // 3),
-                        (pole_x + 2, pole_y + flag_h // 2),
-                    ],
-                )
+                if game_over and not cell.state.is_mine:
+                    pygame.draw.line(self.screen, (200, 200, 0), rect.topleft, rect.bottomright, 3) #for issue 3
+                    pygame.draw.line(self.screen, (200, 200, 0), rect.topright, rect.bottomleft, 3) #for issue3 
+                else:
+                    flag_w = max(6, rect.width // 3)
+                    flag_h = max(8, rect.height // 2)
+                    pole_x = rect.left + rect.width // 3
+                    pole_y = rect.top + 4
+                    pygame.draw.line(self.screen, config.color_flag, (pole_x, pole_y), (pole_x, pole_y + flag_h), 2)
+                    pygame.draw.polygon(
+                        self.screen,
+                        config.color_flag,
+                        [
+                            (pole_x + 2, pole_y),
+                            (pole_x + 2 + flag_w, pole_y + flag_h // 3),
+                            (pole_x + 2, pole_y + flag_h // 2),
+                        ],
+                    )
         pygame.draw.rect(self.screen, config.color_grid, rect, 1)
 
     def draw_header(self, remaining_mines: int, time_text: str) -> None:
@@ -206,7 +210,7 @@ class Game:
         for r in range(self.board.rows):
             for c in range(self.board.cols):
                 highlighted = (now <= self.highlight_until_ms) and ((c, r) in self.highlight_targets)
-                self.renderer.draw_cell(c, r, highlighted)
+                self.renderer.draw_cell(c, r, highlighted, self.board.game_over) #added self.board.game_over for issue 3
         self.renderer.draw_result_overlay(self._result_text())
         pygame.display.flip()
 


### PR DESCRIPTION
Game 클래스의 draw_cell 및 draw(self) 메서드에 변경을 적용했습니다. 게임 종료 시 지뢰가 아닌 깃발을 잘못된 깃발로 표시하도록 했습니다. 또한 Game over 상태에서 이러한 잘못된 깃발 위에 노란색 “X”가 표시되도록 렌더링 로직을 업데이트했습니다.

<img width="649" height="393" alt="image" src="https://github.com/user-attachments/assets/095551c7-0599-4dfa-804f-9069390f202c" />
